### PR TITLE
feat: signup 구현

### DIFF
--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/global/exception/ErrorCode.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/global/exception/ErrorCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode implements BaseCode{
 
 	// ----- [User] ----- //
-	ALREADY_EXIST_USER(HttpStatus.BAD_REQUEST, "이미 존재하는 유저입니다."), UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "접근할 수 없는 유저입니다.");
+	UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "접근할 수 없는 유저입니다."),
+	NOT_EXIST_ROUTE_TYPE(HttpStatus.BAD_REQUEST,"존재하지 않는 이동 수단입니다." );
 
 	private final HttpStatus status;
 	private final String message;

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/global/exception/GlobalExceptionHandler.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/global/exception/GlobalExceptionHandler.java
@@ -16,8 +16,6 @@ public class GlobalExceptionHandler {
 	protected ResponseEntity<BaseApiResponse<Void>> handleCustomException(ApiException ex) {
 		BaseCode errorCode = ex.getBaseCode();
 		log.warn("ApiException handling: {}", ex.getMessage());
-		return ResponseEntity
-			.status(errorCode.getStatus())
-			.body(BaseApiResponse.fail(errorCode));
+		return BaseApiResponse.fail(errorCode);
 	}
 }

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/global/response/BaseApiResponse.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/global/response/BaseApiResponse.java
@@ -5,6 +5,7 @@ import com.ssafy.tomorrowdiray_backend.global.exception.BaseCode;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.ResponseEntity;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -25,25 +26,31 @@ public class BaseApiResponse<T> {
 		this.data = data;
 	}
 
-	public static <T> BaseApiResponse<T> success(BaseCode code) {
-		return BaseApiResponse.<T>builder()
-			.status(SUCCESS)
-			.message(code.getMessage())
-			.build();
+	public static <T> ResponseEntity<BaseApiResponse<T>> success(BaseCode code) {
+		return ResponseEntity
+				.status(code.getStatus())
+				.body(BaseApiResponse.<T>builder()
+						.status(SUCCESS)
+						.message(code.getMessage())
+						.build());
 	}
 
-	public static <T> BaseApiResponse<T> success(BaseCode code, T data) {
-		return BaseApiResponse.<T>builder()
-			.status(SUCCESS)
-			.message(code.getMessage())
-			.data(data)
-			.build();
+	public static <T> ResponseEntity<BaseApiResponse<T>> success(BaseCode code, T data) {
+		return ResponseEntity
+				.status(code.getStatus())
+				.body(BaseApiResponse.<T>builder()
+						.status(SUCCESS)
+						.message(code.getMessage())
+						.data(data)
+						.build());
 	}
 
-	public static <T> BaseApiResponse<T> fail(BaseCode code) {
-		return BaseApiResponse.<T>builder()
-			.status(FAIL)
-			.message(code.getMessage())
-			.build();
+	public static <T> ResponseEntity<BaseApiResponse<T>> fail(BaseCode code) {
+		return ResponseEntity
+				.status(code.getStatus())
+				.body(BaseApiResponse.<T>builder()
+						.status(FAIL)
+						.message(code.getMessage())
+						.build());
 	}
 }

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/controller/UserController.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/controller/UserController.java
@@ -6,6 +6,11 @@ import com.ssafy.tomorrowdiray_backend.user.dto.request.SignupRequest;
 import com.ssafy.tomorrowdiray_backend.user.dto.response.SignupResponse;
 import com.ssafy.tomorrowdiray_backend.user.entity.User;
 import com.ssafy.tomorrowdiray_backend.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,9 +21,21 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
     private final UserService userService;
 
+    @Operation(
+            summary = "회원가입 API",
+            description = "OAuth 로그인 중 우리 서비스 사용자가 아닌 경우 회원가입을 요청합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "회원가입 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = SignupResponse.class)
+            )
+    )
     @PostMapping("/sign-up")
     public ResponseEntity<BaseApiResponse<SignupResponse>> signup(
-            @SessionAttribute User user,
+            @Parameter(hidden = true) @SessionAttribute User user,
             @RequestBody SignupRequest request) {
         SignupResponse response = userService.signup(user, request);
         return BaseApiResponse.success(StatusCode.SIGNUP_SUCCESS, response);

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/controller/UserController.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.ssafy.tomorrowdiray_backend.user.controller;
+
+import com.ssafy.tomorrowdiray_backend.global.exception.StatusCode;
+import com.ssafy.tomorrowdiray_backend.global.response.BaseApiResponse;
+import com.ssafy.tomorrowdiray_backend.user.dto.request.SignupRequest;
+import com.ssafy.tomorrowdiray_backend.user.dto.response.SignupResponse;
+import com.ssafy.tomorrowdiray_backend.user.entity.User;
+import com.ssafy.tomorrowdiray_backend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/user")
+@RequiredArgsConstructor
+@RestController
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<BaseApiResponse<SignupResponse>> signup(
+            @SessionAttribute User user,
+            @RequestBody SignupRequest request) {
+        SignupResponse response = userService.signup(user, request);
+        return BaseApiResponse.success(StatusCode.SIGNUP_SUCCESS, response);
+    }
+
+
+}

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/dto/request/SignupRequest.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/dto/request/SignupRequest.java
@@ -1,6 +1,7 @@
 package com.ssafy.tomorrowdiray_backend.user.dto.request;
 
 import com.ssafy.tomorrowdiray_backend.user.entity.RouteType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +15,10 @@ public class SignupRequest {
     private double latitude;
     private double longitude;
     private RouteType routeType;
+    @Schema(description = "출근 시간", example = "07:30:00")
     private LocalTime startTime;
+
+    @Schema(description = "퇴근 시간", example = "18:00:00")
     private LocalTime endTime;
 
     @Builder

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/dto/request/SignupRequest.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/dto/request/SignupRequest.java
@@ -1,0 +1,29 @@
+package com.ssafy.tomorrowdiray_backend.user.dto.request;
+
+import com.ssafy.tomorrowdiray_backend.user.entity.RouteType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequest {
+    private String roadAddress;
+    private double latitude;
+    private double longitude;
+    private RouteType routeType;
+    private LocalTime startTime;
+    private LocalTime endTime;
+
+    @Builder
+    public SignupRequest(String roadAddress, double latitude, double longitude, String routeType, LocalTime startTime, LocalTime endTime) {
+        this.roadAddress = roadAddress;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.routeType = RouteType.fromString(routeType);
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+}

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/dto/response/SignupResponse.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/dto/response/SignupResponse.java
@@ -1,0 +1,22 @@
+package com.ssafy.tomorrowdiray_backend.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupResponse {
+    private String nickname;
+
+    @Builder
+    public SignupResponse(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public static SignupResponse toDto(String nickname) {
+        return SignupResponse.builder()
+                .nickname(nickname)
+                .build();
+    }
+}

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/entity/RouteType.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/entity/RouteType.java
@@ -1,0 +1,33 @@
+package com.ssafy.tomorrowdiray_backend.user.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.ssafy.tomorrowdiray_backend.global.exception.ErrorCode;
+import com.ssafy.tomorrowdiray_backend.user.exception.UserSignupException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RouteType {
+    자가용(1), 대중교통(2), 도보(3);
+
+    private final long order;
+
+    // Enum 값을 문자열로 변환
+    @JsonValue
+    public String toValue() {
+        return name();
+    }
+
+    // 문자열을 Enum으로 변환
+    @JsonCreator
+    public static RouteType fromString(String value) {
+        for (RouteType routeType : RouteType.values()) {
+            if (routeType.name().equals(value)) {
+                return routeType;
+            }
+        }
+        throw new UserSignupException(ErrorCode.NOT_EXIST_ROUTE_TYPE);
+    }
+}

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/entity/User.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/entity/User.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalTime;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -14,7 +16,9 @@ public class User {
 	private Long id;
 	private Long socialId;
 	private String nickname;
-	private String destinationAddress;
+	private LocalTime startTime;
+	private LocalTime endTime;
 	private Role role;
 	private Long transportTypeId;
+	private Long usersDestinationId;
 }

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/entity/UserDestination.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/entity/UserDestination.java
@@ -1,0 +1,20 @@
+package com.ssafy.tomorrowdiray_backend.user.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserDestination {
+    private Long id;
+    private String destinationAddress;
+    private double latitude;
+    private double longitude;
+
+    @Builder
+    public UserDestination(Long id, String destinationAddress, double latitude, double longitude) {
+        this.id = id;
+        this.destinationAddress = destinationAddress;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/exception/UserSignupException.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/exception/UserSignupException.java
@@ -1,0 +1,10 @@
+package com.ssafy.tomorrowdiray_backend.user.exception;
+
+import com.ssafy.tomorrowdiray_backend.global.exception.ApiException;
+import com.ssafy.tomorrowdiray_backend.global.exception.ErrorCode;
+
+public class UserSignupException extends ApiException {
+    public UserSignupException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/repository/UserRepository.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.ssafy.tomorrowdiray_backend.user.repository;
+
+
+import com.ssafy.tomorrowdiray_backend.user.entity.UserDestination;
+
+import java.time.LocalTime;
+
+public interface UserRepository {
+
+    Long insertDestination(UserDestination userDestination);
+
+    void insert(Long socialId, String nickname, LocalTime startTime, LocalTime endTime, Long transportTypeId, Long usersDestinationId);
+}

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/service/UserService.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/service/UserService.java
@@ -1,0 +1,42 @@
+package com.ssafy.tomorrowdiray_backend.user.service;
+
+import com.ssafy.tomorrowdiray_backend.user.dto.request.SignupRequest;
+import com.ssafy.tomorrowdiray_backend.user.dto.response.SignupResponse;
+import com.ssafy.tomorrowdiray_backend.user.entity.User;
+import com.ssafy.tomorrowdiray_backend.user.entity.UserDestination;
+import com.ssafy.tomorrowdiray_backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public SignupResponse signup(User user, SignupRequest request) {
+
+        Long socialId = user.getSocialId();
+        String nickname = user.getNickname();
+
+        LocalTime startTime = request.getStartTime();
+        LocalTime endTime = request.getEndTime();
+        Long transportTypeId = request.getRouteType().getOrder();
+        Long usersDestinationId = registDestination(request.getRoadAddress(), request.getLatitude(), request.getLongitude());
+
+        userRepository.insert(socialId, nickname, startTime, endTime, transportTypeId, usersDestinationId);
+
+        return SignupResponse.toDto(nickname);
+    }
+
+    public Long registDestination(String roadAddress, double latitude, double longitude) {
+        return userRepository.insertDestination(
+                UserDestination.builder()
+                        .destinationAddress(roadAddress)
+                        .latitude(latitude)
+                        .longitude(longitude)
+                        .build());
+    }
+}

--- a/tomorrowdiray_backend/src/main/resources/mapper/userMapper.xml
+++ b/tomorrowdiray_backend/src/main/resources/mapper/userMapper.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.ssafy.tomorrowdiray_backend.user.repository.UserRepository">
+
+    <!-- ResultMap 정의 -->
+    <resultMap id="userResultMap" type="com.ssafy.tomorrowdiray_backend.user.entity.User">
+        <id property="id" column="id" />
+        <result property="socialId" column="social_id" />
+        <result property="nickname" column="nickname" />
+        <result property="startTime" column="start_time" />
+        <result property="endTime" column="end_time" />
+        <result property="role" column="role" />
+        <result property="transportTypeId" column="transport_type_id" />
+        <result property="usersDestinationId" column="users_destination_id" />
+    </resultMap>
+
+    <insert id="insert">
+        INSERT INTO users (
+            social_id,
+            nickname,
+            start_time,
+            end_time,
+            transport_type_id,
+            users_destination_id
+        ) VALUES (
+            #{socialId},
+            #{nickname},
+            #{startTime},
+            #{endTime},
+            #{transportTypeId},
+            #{usersDestinationId}
+        )
+    </insert>
+
+    <insert id="insertDestination" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO users_destination (
+            destination_address,
+            latitude,
+            longitude
+        ) VALUES (
+            #{destinationAddress},
+            #{latitude},
+            #{longitude}
+        )
+    </insert>
+
+</mapper>


### PR DESCRIPTION
## What is this PR? 👓
유저 회원가입 기능을 구현했습니다.

## Key changes 🔑
BaseApiResponse return type을 ResponseEntity로 변경했습니다.

## To reviewers 👋
exception 핸들링을 위해 errorcode enum을 만들었습니다. 이 곳에 HttpStatus와 message를 명시적으로 작성해주시면 됩니다.
더해서 각 도메인에서 예외 발생하는 경우를 핸들링 하려면 `UserSignupException` 처럼 ApiException을 상속 받아 사용해주시면 됩니다.
swagger-ui 는 `http://localhost:8080/swagger-ui/index.html`으로 접근 가능합니다.

### 중요
login api 구현할 때 우리 회원이 아니라 회원가입을 요청해야 할 때 세션에 socialId와 nickname을 저장하도록 만들어주세요
