### PR TITLE
[BE] 회원가입 시 바로 로그인할 수 있도록 수정

### DIFF
--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/global/exception/StatusCode.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/global/exception/StatusCode.java
@@ -12,7 +12,8 @@ public enum StatusCode implements BaseCode{
 	// ----- [User] ----- //
 	SIGNUP_SUCCESS(HttpStatus.OK, "회원가입 성공"),
 	LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
-	REQUIRED_SIGNUP(HttpStatus.ACCEPTED, "회원가입이 필요합니다.");
+	REQUIRED_SIGNUP(HttpStatus.ACCEPTED, "회원가입이 필요합니다."),
+	LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공");
 
 	private final HttpStatus status;
 	private final String message;

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/controller/UserController.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/controller/UserController.java
@@ -73,4 +73,19 @@ public class UserController {
         cookie.setMaxAge(60 * 60);
         return cookie;
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<BaseApiResponse<Void>> logout(
+            HttpSession session,
+            HttpServletResponse response) {
+        session.invalidate();
+
+        Cookie sessionIdCookie = new Cookie("SESSIONID", null);
+        sessionIdCookie.setPath("/");
+        sessionIdCookie.setHttpOnly(true);
+        sessionIdCookie.setMaxAge(0);
+        response.addCookie(sessionIdCookie);
+
+        return BaseApiResponse.success(StatusCode.LOGOUT_SUCCESS);
+    }
 }

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/dto/response/SignupResponse.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/dto/response/SignupResponse.java
@@ -1,5 +1,6 @@
 package com.ssafy.tomorrowdiray_backend.user.dto.response;
 
+import com.ssafy.tomorrowdiray_backend.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,9 +15,9 @@ public class SignupResponse {
         this.nickname = nickname;
     }
 
-    public static SignupResponse toDto(String nickname) {
+    public static SignupResponse toDto(User user) {
         return SignupResponse.builder()
-                .nickname(nickname)
+                .nickname(user.getNickname())
                 .build();
     }
 }

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/repository/UserRepository.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/repository/UserRepository.java
@@ -5,14 +5,13 @@ import com.ssafy.tomorrowdiray_backend.user.dto.SocialUser;
 import com.ssafy.tomorrowdiray_backend.user.entity.User;
 import com.ssafy.tomorrowdiray_backend.user.entity.UserDestination;
 
-import java.time.LocalTime;
 import java.util.Optional;
 
 public interface UserRepository {
 
     Long insertDestination(UserDestination userDestination);
 
-    void insert(Long socialId, String nickname, LocalTime startTime, LocalTime endTime, Long transportTypeId, Long usersDestinationId);
-
 	Optional<User> findBySocialUser(SocialUser socialUser);
+
+    void insert(User user);
 }

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/service/KakaoLoginService.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/service/KakaoLoginService.java
@@ -44,8 +44,9 @@ public class KakaoLoginService implements LoginService {
 		}
 
 		return SocialUser.builder()
-			.user(user.get())
-			.build();
+				.nickname(socialUser.getNickname())
+				.user(user.get())
+				.build();
 	}
 
 	public String getAccessTokenFromKakao(String code) {

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/service/UserService.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.ssafy.tomorrowdiray_backend.user.service;
 
 import com.ssafy.tomorrowdiray_backend.user.dto.request.SignupRequest;
 import com.ssafy.tomorrowdiray_backend.user.dto.response.SignupResponse;
+import com.ssafy.tomorrowdiray_backend.user.entity.User;
 import com.ssafy.tomorrowdiray_backend.user.entity.UserDestination;
 import com.ssafy.tomorrowdiray_backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,16 +19,24 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public SignupResponse signup(Long socialId, String nickname, SignupRequest request) {
+    public User signup(Long socialId, String nickname, SignupRequest request) {
         LocalTime startTime = request.getStartTime();
         LocalTime endTime = request.getEndTime();
         Long transportTypeId = request.getRouteType().getOrder();
 
         UserDestination userDestination = registDestination(request.getRoadAddress(), request.getLatitude(), request.getLongitude());
 
-        userRepository.insert(socialId, nickname, startTime, endTime, transportTypeId, userDestination.getId());
+        User user = User.builder()
+                .socialId(socialId)
+                .nickname(nickname)
+                .startTime(startTime)
+                .endTime(endTime)
+                .transportTypeId(transportTypeId)
+                .usersDestinationId(userDestination.getId())
+                .build();
+        userRepository.insert(user);
 
-        return SignupResponse.toDto(nickname);
+        return user;
     }
 
     @Transactional

--- a/tomorrowdiray_backend/src/main/resources/mapper/userMapper.xml
+++ b/tomorrowdiray_backend/src/main/resources/mapper/userMapper.xml
@@ -16,7 +16,7 @@
         <result property="usersDestinationId" column="users_destination_id" />
     </resultMap>
 
-    <insert id="insert">
+    <insert id="insert" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO users (
             social_id,
             nickname,


### PR DESCRIPTION
## What is this PR? 👓
회원가입 시 성공 응답만 나오고 세션은 만들지 않고 있는 상황이었습니다. 소셜 로그인을 진행하며 회원가입 후 다시 소셜 로그인을 요청하는 흐름이 좋지 않아 회원가입하면 바로 세션을 만들도록 설정했습니다.

## Key changes 🔑
application.properties에 cookie 관련 설정 추가했습니다.

## To reviewers 👋
`JSESSIONID`는 세션을 생성하면 자동으로 Cookie에 HttpOnly와 secure 옵션을 설정하여 만들었습니다. 로그아웃 시에만 세션을 명시적으로 쿠키에서 삭제했습니다. 쿠키의 secure 옵션은 properties 파일에서 확인할 수 있습니다.