### PR TITLE
[BE] 아파트 상세 조회 API 구현

### DIFF
--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/global/exception/StatusCode.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/global/exception/StatusCode.java
@@ -19,7 +19,8 @@ public enum StatusCode implements BaseCode{
 	SEARCH_ADDRESS_SUCCESS(HttpStatus.OK, "주소 검색 성공" ),
 
 	// ----- [House] ----- //
-	SHOW_HOUSE_SUCCESS(HttpStatus.OK, "아파트 조회 성공"),;
+	SHOW_HOUSE_SUCCESS(HttpStatus.OK, "아파트 상세 조회 성공"),
+	SHOW_HOUSE_LIST_SUCCESS(HttpStatus.OK,"아파트 리스트 조회 성공" );
 
 	private final HttpStatus status;
 	private final String message;

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/controller/HouseController.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/controller/HouseController.java
@@ -30,6 +30,10 @@ public class HouseController {
         return BaseApiResponse.success(StatusCode.SHOW_HOUSE_LIST_SUCCESS, responses);
     }
 
+    @Operation(summary = "아파트 상세 조회 API", description = "aptSeq으로 아파트 상세 데이터를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "아파트 상세 조회 성공")
+    })
     @GetMapping("/{aptSeq}")
     public ResponseEntity<BaseApiResponse<HouseDetailResponse>> getHouse(@PathVariable String aptSeq) {
         HouseDetailResponse response = houseService.getHouseByAptSeq(aptSeq);

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/controller/HouseController.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/controller/HouseController.java
@@ -2,6 +2,7 @@ package com.ssafy.tomorrowdiray_backend.house.controller;
 
 import com.ssafy.tomorrowdiray_backend.global.exception.StatusCode;
 import com.ssafy.tomorrowdiray_backend.global.response.BaseApiResponse;
+import com.ssafy.tomorrowdiray_backend.house.dto.response.HouseDetailResponse;
 import com.ssafy.tomorrowdiray_backend.house.dto.response.HouseResponse;
 import com.ssafy.tomorrowdiray_backend.house.service.HouseService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,6 +27,12 @@ public class HouseController {
     @GetMapping
     public ResponseEntity<BaseApiResponse<List<HouseResponse>>> getHouses(@RequestParam String dongcode) {
         List<HouseResponse> responses = houseService.getHouses(dongcode);
-        return BaseApiResponse.success(StatusCode.SHOW_HOUSE_SUCCESS, responses);
+        return BaseApiResponse.success(StatusCode.SHOW_HOUSE_LIST_SUCCESS, responses);
+    }
+
+    @GetMapping("/{aptSeq}")
+    public ResponseEntity<BaseApiResponse<HouseDetailResponse>> getHouse(@PathVariable String aptSeq) {
+        HouseDetailResponse response = houseService.getHouseByAptSeq(aptSeq);
+        return BaseApiResponse.success(StatusCode.SHOW_HOUSE_SUCCESS, response);
     }
 }

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/dto/HouseDealInfo.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/dto/HouseDealInfo.java
@@ -1,0 +1,26 @@
+package com.ssafy.tomorrowdiray_backend.house.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class HouseDealInfo {
+    private Long id;
+    private int floor;
+    private LocalDate dealDate;
+    private Double userArea;
+    private String dealAmount;
+
+    @Builder
+    public HouseDealInfo(Long id, int floor, LocalDate dealDate, Double userArea, String dealAmount) {
+        this.id = id;
+        this.floor = floor;
+        this.dealDate = dealDate;
+        this.userArea = userArea;
+        this.dealAmount = dealAmount;
+    }
+}

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/dto/response/HouseDetailResponse.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/dto/response/HouseDetailResponse.java
@@ -1,0 +1,30 @@
+package com.ssafy.tomorrowdiray_backend.house.dto.response;
+
+import com.ssafy.tomorrowdiray_backend.house.dto.HouseDealInfo;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class HouseDetailResponse {
+    private String aptSeq;
+    private String name;
+    private int buildYear;
+    private String roadAddress;
+    private String jibunAddress;
+
+    private List<HouseDealInfo> houseDealInfoList;
+
+    @Builder
+    public HouseDetailResponse(String aptSeq, String name, int buildYear, String roadAddress, String jibunAddress, List<HouseDealInfo> houseDealInfoList) {
+        this.aptSeq = aptSeq;
+        this.name = name;
+        this.buildYear = buildYear;
+        this.roadAddress = roadAddress;
+        this.jibunAddress = jibunAddress;
+        this.houseDealInfoList = houseDealInfoList;
+    }
+}

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/repository/HouseRepository.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/repository/HouseRepository.java
@@ -1,5 +1,6 @@
 package com.ssafy.tomorrowdiray_backend.house.repository;
 
+import com.ssafy.tomorrowdiray_backend.house.dto.response.HouseDetailResponse;
 import com.ssafy.tomorrowdiray_backend.house.entity.House;
 
 import java.util.List;
@@ -7,4 +8,6 @@ import java.util.List;
 public interface HouseRepository {
 
     List<House> selectByDongcode(String dongcode);
+
+    HouseDetailResponse selectByAptSeq(String aptSeq);
 }

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/service/HouseService.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/service/HouseService.java
@@ -18,9 +18,9 @@ public class HouseService {
     private final HouseRepository houseRepository;
 
     public List<HouseResponse> getHouses(String dongcode) {
-        List<House> houses = houseRepository.selectByDongcode(dongcode);
-        List<HouseResponse> responses = houses.stream().map(HouseResponse::toDto).toList();
-        return responses;
+        return houseRepository.selectByDongcode(dongcode).stream()
+                .map(HouseResponse::toDto)
+                .toList();
     }
 
     public HouseDetailResponse getHouseByAptSeq(String aptSeq) {

--- a/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/service/HouseService.java
+++ b/tomorrowdiray_backend/src/main/java/com/ssafy/tomorrowdiray_backend/house/service/HouseService.java
@@ -1,5 +1,6 @@
 package com.ssafy.tomorrowdiray_backend.house.service;
 
+import com.ssafy.tomorrowdiray_backend.house.dto.response.HouseDetailResponse;
 import com.ssafy.tomorrowdiray_backend.house.dto.response.HouseResponse;
 import com.ssafy.tomorrowdiray_backend.house.entity.House;
 import com.ssafy.tomorrowdiray_backend.house.repository.HouseRepository;
@@ -20,5 +21,9 @@ public class HouseService {
         List<House> houses = houseRepository.selectByDongcode(dongcode);
         List<HouseResponse> responses = houses.stream().map(HouseResponse::toDto).toList();
         return responses;
+    }
+
+    public HouseDetailResponse getHouseByAptSeq(String aptSeq) {
+         return houseRepository.selectByAptSeq(aptSeq);
     }
 }

--- a/tomorrowdiray_backend/src/main/resources/mapper/houseMapper.xml
+++ b/tomorrowdiray_backend/src/main/resources/mapper/houseMapper.xml
@@ -25,4 +25,45 @@
         from house_infos
         where concat(sgg_cd, umd_cd) = #{dongcode};
     </select>
+
+    <!-- HouseDetailResponse와 매핑 -->
+    <resultMap id="houseDetailResponseMap" type="com.ssafy.tomorrowdiray_backend.house.dto.response.HouseDetailResponse">
+        <id property="aptSeq" column="apt_seq" />
+        <result property="name" column="apt_nm" />
+        <result property="buildYear" column="build_year" />
+        <result property="roadAddress" column="road_address" />
+        <result property="jibunAddress" column="jibun_address" />
+        <collection property="houseDealInfoList" ofType="com.ssafy.tomorrowdiray_backend.house.dto.HouseDealInfo">
+            <id property="id" column="id" />
+            <result property="floor" column="floor" />
+            <result property="dealDate" column="deal_date" javaType="java.time.LocalDate" />
+            <result property="userArea" column="exclu_use_ar" />
+            <result property="dealAmount" column="deal_amount" />
+        </collection>
+    </resultMap>
+
+    <!-- 아파트 상세 정보 및 실거래 내역 조회 -->
+    <select id="selectByAptSeq" resultMap="houseDetailResponseMap">
+        select
+            h.apt_seq,
+            h.apt_nm,
+            h.build_year,
+            CONCAT(dc.sido_name,' ',dc.gugun_name,' ', h.road_nm, ' ', h.road_nm_bonbun, IF(h.road_nm_bubun != 0, CONCAT('-', h.road_nm_bubun), '')) as road_address,
+            CONCAT(dc.sido_name, ' ', dc.gugun_name, ' ', dc.dong_name, ' ', h.jibun) as jibun_address,
+            d.id,
+            d.floor,
+            STR_TO_DATE(CONCAT(d.deal_year, '-', d.deal_month, '-', d.deal_day), '%Y-%m-%d') as deal_date,
+            d.exclu_use_ar,
+            d.deal_amount
+        from
+            house_infos h
+        left join
+            house_deals d on h.apt_seq = d.house_infos_apt_seq
+        left join
+            dongcodes dc on CONCAT(h.sgg_cd, h.umd_cd) = dc.dong_code
+        where
+            h.apt_seq = #{aptSeq}
+        ORDER BY deal_date DESC
+        limit 10;
+    </select>
 </mapper>


### PR DESCRIPTION
## What is this PR? 👓
주택 상세 조회 API 구현 완료했습니다.

## Key changes 🔑
아파트 상세 조회 API 명세서 변경했습니다. 

## To reviewers 👋
`HouseDetailResponse` dto에서 아파트 정보 데이터를, 이 클래스 내부에 `List<HouseDealInfo>`를 만들어 하나의 아파트에 여러 실거래 내역이 리스트로 응답할 수 있도록 만들었습니다.
거래 내역 리스트는 날짜 내림차순 상위 10개가 응답합니다.
 